### PR TITLE
feat: cache Prisma client globally

### DIFF
--- a/detect-app/lib/prisma.ts
+++ b/detect-app/lib/prisma.ts
@@ -1,0 +1,4 @@
+import { PrismaClient } from '@prisma/client';
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## Summary
- cache Prisma client instance in a global variable to avoid multiple connections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b795a802b88332af599a65b41f9819